### PR TITLE
#30 [FEAT] IoT 기기 제어 명령 API

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/server/src/main/java/org/cecd/server/common/BaseTimeEntity.java
+++ b/server/src/main/java/org/cecd/server/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.cecd.server.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/server/src/main/java/org/cecd/server/controller/CommandController.java
+++ b/server/src/main/java/org/cecd/server/controller/CommandController.java
@@ -1,0 +1,26 @@
+package org.cecd.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.cecd.server.dto.CommandRequest;
+import org.cecd.server.service.CommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/command")
+@RequiredArgsConstructor
+public class CommandController {
+
+    private final CommandService commandService;
+
+    @PostMapping
+    public ResponseEntity<String> sendControlCommand(@RequestBody CommandRequest commandRequest) {
+        String result = commandService.forwardToAgent(commandRequest);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/echo")
+    public ResponseEntity<CommandRequest> echoControlCommand(@RequestBody CommandRequest commandRequest) {
+        return ResponseEntity.ok(commandRequest);
+    }
+}

--- a/server/src/main/java/org/cecd/server/controller/CommandController.java
+++ b/server/src/main/java/org/cecd/server/controller/CommandController.java
@@ -7,19 +7,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/command")
+@RequestMapping
 @RequiredArgsConstructor
 public class CommandController {
 
     private final CommandService commandService;
 
-    @PostMapping
+    @PostMapping("/control")
     public ResponseEntity<String> sendControlCommand(@RequestBody CommandRequest commandRequest) {
         String result = commandService.forwardToAgent(commandRequest);
         return ResponseEntity.ok(result);
     }
 
-    @PostMapping("/echo")
+    @PostMapping("/command")
     public ResponseEntity<CommandRequest> echoControlCommand(@RequestBody CommandRequest commandRequest) {
         return ResponseEntity.ok(commandRequest);
     }

--- a/server/src/main/java/org/cecd/server/domain/Command.java
+++ b/server/src/main/java/org/cecd/server/domain/Command.java
@@ -18,7 +18,7 @@ public class Command extends BaseTimeEntity {
     private Long commandId;
 
     @Column(nullable = false)
-    private String senserNumber;
+    private String sensorId;
 
     @Column(nullable = false)
     private boolean command; // true : ON, false : OFF

--- a/server/src/main/java/org/cecd/server/domain/Command.java
+++ b/server/src/main/java/org/cecd/server/domain/Command.java
@@ -1,0 +1,26 @@
+package org.cecd.server.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.cecd.server.common.BaseTimeEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class Command extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "command_id")
+    private Long commandId;
+
+    @Column(nullable = false)
+    private String senserNumber;
+
+    @Column(nullable = false)
+    private boolean command; // true : ON, false : OFF
+
+}

--- a/server/src/main/java/org/cecd/server/dto/CommandRequest.java
+++ b/server/src/main/java/org/cecd/server/dto/CommandRequest.java
@@ -1,11 +1,12 @@
 package org.cecd.server.dto;
 
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class CommandRequest {
-    private String senserNumber;
+    private String sensorId;
     private boolean command;
 }

--- a/server/src/main/java/org/cecd/server/dto/CommandRequest.java
+++ b/server/src/main/java/org/cecd/server/dto/CommandRequest.java
@@ -1,0 +1,11 @@
+package org.cecd.server.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommandRequest {
+    private String senserNumber;
+    private boolean command;
+}

--- a/server/src/main/java/org/cecd/server/repository/CommandRepository.java
+++ b/server/src/main/java/org/cecd/server/repository/CommandRepository.java
@@ -1,0 +1,7 @@
+package org.cecd.server.repository;
+
+import org.cecd.server.domain.Command;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommandRepository extends JpaRepository<Command, Long> {
+}

--- a/server/src/main/java/org/cecd/server/service/CommandService.java
+++ b/server/src/main/java/org/cecd/server/service/CommandService.java
@@ -1,0 +1,20 @@
+package org.cecd.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cecd.server.dto.CommandRequest;
+import org.cecd.server.utils.AgentClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommandService {
+
+    private final AgentClient agentClient;
+
+    public String forwardToAgent(CommandRequest commandRequest) {
+        // agent로 POST 요청
+        return agentClient.sendCommand(commandRequest);
+    }
+
+}
+

--- a/server/src/main/java/org/cecd/server/utils/AgentClient.java
+++ b/server/src/main/java/org/cecd/server/utils/AgentClient.java
@@ -26,7 +26,7 @@ public class AgentClient {
             restTemplate.postForEntity(AGENT_URL, request, String.class);
             return "Command sent successfully!";
         } catch (Exception e) {
-            return "Failed to send command to agent: " + e.getMessage();
+            return "Failed to send command: " + e.getMessage();
         }
     }
 }

--- a/server/src/main/java/org/cecd/server/utils/AgentClient.java
+++ b/server/src/main/java/org/cecd/server/utils/AgentClient.java
@@ -1,0 +1,32 @@
+package org.cecd.server.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.cecd.server.dto.CommandRequest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class AgentClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String AGENT_URL = /*agent-server-ip*/ "http://192.168.0.113:3000/control";
+
+    public String sendCommand(CommandRequest commandRequest) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<CommandRequest> request = new HttpEntity<>(commandRequest, headers);
+
+        try {
+            restTemplate.postForEntity(AGENT_URL, request, String.class);
+            return "Command sent successfully!";
+        } catch (Exception e) {
+            return "Failed to send command to agent: " + e.getMessage();
+        }
+    }
+}

--- a/server/src/test/java/org/cecd/server/controller/CommandControllerTest.java
+++ b/server/src/test/java/org/cecd/server/controller/CommandControllerTest.java
@@ -1,0 +1,47 @@
+package org.cecd.server.controller;
+
+import org.cecd.server.dto.CommandRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CommandControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void sendControlCommand() {
+        // 요청 데이터 생성
+        CommandRequest commandRequest = new CommandRequest();
+        commandRequest.setSenserNumber("12345");
+        commandRequest.setCommand(true);
+
+        // HTTP 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        // 요청 엔티티 생성
+        HttpEntity<CommandRequest> request = new HttpEntity<>(commandRequest, headers);
+
+        // 테스트용 엔드포인트로 POST 요청 전송
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/command",
+                HttpMethod.POST,
+                request,
+                String.class
+        );
+
+        // 응답 검증
+        assertThat(response.getStatusCodeValue()).isEqualTo(200); // 상태 코드 검증
+        assertThat(response.getBody()).contains("Command sent successfully"); // 응답 메시지 검증
+    }
+}

--- a/server/src/test/java/org/cecd/server/controller/CommandControllerTest.java
+++ b/server/src/test/java/org/cecd/server/controller/CommandControllerTest.java
@@ -20,16 +20,15 @@ class CommandControllerTest {
 
     @Test
     void sendControlCommand() {
+
         // 요청 데이터 생성
         CommandRequest commandRequest = new CommandRequest();
-        commandRequest.setSenserNumber("12345");
+        commandRequest.setSensorId("000100010000000093");
         commandRequest.setCommand(true);
 
-        // HTTP 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/json");
 
-        // 요청 엔티티 생성
         HttpEntity<CommandRequest> request = new HttpEntity<>(commandRequest, headers);
 
         // 테스트용 엔드포인트로 POST 요청 전송


### PR DESCRIPTION
## ✨ Related Issue

- Resolve : #30 

## 📝 기능 구현 명세

- IoT 기기 제어 명령을 전송하는 POST API를 구현했습니다. 
- 단순히 JSON 형태의 센서번호와 요청 정보(On/Off)만을 전달하는 API와 
https://github.com/CSID-DGU/2024-1-CECD1-1921-3/blob/a30905b812b532217f4f306c34c2c598d3c60c88/server/src/main/java/org/cecd/server/controller/CommandController.java#L22-L24
- agent.js의 서버(서버 주소는 수정 필요)로 요청을 보내는 API를 나눠서 구현했고, 필요한 경우 수정하겠습니다. (구현 과정에서 더 적절한걸로 골라서 쓰시면 될 것 같고, 나중에 필요없는 API는 삭제하려고 합니다)
https://github.com/CSID-DGU/2024-1-CECD1-1921-3/blob/a30905b812b532217f4f306c34c2c598d3c60c88/server/src/main/java/org/cecd/server/controller/CommandController.java#L22-L24
- 서버 주소
https://github.com/CSID-DGU/2024-1-CECD1-1921-3/blob/a30905b812b532217f4f306c34c2c598d3c60c88/server/src/main/java/org/cecd/server/utils/AgentClient.java#L16


<img width="621" alt="스크린샷 2024-11-19 오후 7 07 20" src="https://github.com/user-attachments/assets/2cbcb1da-7e02-4990-8f2e-480aff2ff027">

